### PR TITLE
Fix warnings

### DIFF
--- a/modules/bastion/iam.tf
+++ b/modules/bastion/iam.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_instance_profile" "s3_readonly" {
   name = "${var.name}-s3-readonly"
-  role = "${aws_iam_role.s3_readonly.name}"
+  role = aws_iam_role.s3_readonly.name
 }
 
 resource "aws_iam_role" "s3_readonly" {
@@ -25,7 +25,7 @@ EOF
 
 resource "aws_iam_role_policy" "s3_readonly_policy" {
   name = "${var.name}-s3-readonly-policy"
-  role = "${aws_iam_role.s3_readonly.id}"
+  role = aws_iam_role.s3_readonly.id
 
   policy = <<EOF
 {
@@ -38,7 +38,7 @@ resource "aws_iam_role_policy" "s3_readonly_policy" {
                 "s3:Get*"
             ],
             "Resource": [
-              "${var.s3_bucket_arn}",
+              var.s3_bucket_arn,
               "${var.s3_bucket_arn}/*"
             ]
         }

--- a/modules/bastion/output.tf
+++ b/modules/bastion/output.tf
@@ -1,7 +1,7 @@
 output "ssh_user" {
-  value = "${var.ssh_user}"
+  value = var.ssh_user
 }
 
 output "security_group_id" {
-  value = "${aws_security_group.bastion.id}"
+  value = aws_security_group.bastion.id
 }

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -58,7 +58,7 @@ variable "associate_public_ip_address" {
 
 variable "allow_ssh_cidrs" {
   description = "List Cidrs from where ssh is to be allowed for bastion host. Default is anywhere"
-  type        = "list"
+  type        = list
   default     = ["0.0.0.0/0"]
 }
 

--- a/modules/nat/main.tf
+++ b/modules/nat/main.tf
@@ -1,7 +1,7 @@
 resource "aws_eip" "nat" {
   vpc = true
 
-  count = "${length(var.azs)}" # Comment out count to only have 1 NAT
+  count = length(var.azs) # Comment out count to only have 1 NAT
 
   lifecycle {
     create_before_destroy = true
@@ -9,10 +9,10 @@ resource "aws_eip" "nat" {
 }
 
 resource "aws_nat_gateway" "nat" {
-  count = "${length(var.azs)}" # Comment out count to only have 1 NAT
+  count = length(var.azs) # Comment out count to only have 1 NAT
 
-  allocation_id = "${element(aws_eip.nat.*.id, count.index)}"
-  subnet_id     = "${element(split(",", var.public_subnet_ids), count.index)}"
+  allocation_id = element(aws_eip.nat.*.id, count.index)
+  subnet_id     = element(split(",", var.public_subnet_ids), count.index)
 
   lifecycle {
     create_before_destroy = true

--- a/modules/nat/output.tf
+++ b/modules/nat/output.tf
@@ -1,7 +1,7 @@
 output "nat_gateway_ids" {
-  value = "${join(",", aws_nat_gateway.nat.*.id)}"
+  value = join(",", aws_nat_gateway.nat.*.id)
 }
 
 output "public_ip" {
-  value = "${aws_eip.nat.public_ip}"
+  value = aws_eip.nat.public_ip
 }

--- a/modules/network-acl/main.tf
+++ b/modules/network-acl/main.tf
@@ -1,6 +1,6 @@
 resource "aws_network_acl" "acl" {
-  vpc_id     = "${var.vpc_id}"
-  subnet_ids = ["${concat(split(",", var.public_subnet_ids), split(",", var.private_app_subnet_ids))}"]
+  vpc_id     = var.vpc_id
+  subnet_ids = [concat(split(",", var.public_subnet_ids), split(",", var.private_app_subnet_ids))]
 
   ingress {
     protocol   = "-1"
@@ -21,6 +21,6 @@ resource "aws_network_acl" "acl" {
   }
 
   tags {
-    Name = "${var.name}"
+    Name = var.name
   }
 }

--- a/modules/network-acl/output.tf
+++ b/modules/network-acl/output.tf
@@ -1,3 +1,3 @@
 output "network_acl_id" {
-  value = "${aws_network_acl.acl.id}"
+  value = aws_network_acl.acl.id
 }

--- a/modules/network.tf
+++ b/modules/network.tf
@@ -67,7 +67,7 @@ variable "bastion_host_keypair" {
 
 variable "bastion_host_allow_ssh_cidrs" {
   description = "List Cidrs from where ssh is to be allowed for bastion host. Default is anywhere"
-  type        = "list"
+  type        = list
   default     = ["0.0.0.0/0"]
 }
 

--- a/modules/private-app-subnet/main.tf
+++ b/modules/private-app-subnet/main.tf
@@ -1,10 +1,10 @@
 resource "aws_route_table" "private" {
-  vpc_id = "${var.vpc_id}"
-  count  = "${length(var.azs)}"
+  vpc_id = var.vpc_id
+  count  = length(var.azs)
 
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = "${element(split(",", var.nat_gateway_ids), count.index)}"
+    nat_gateway_id = element(split(",", var.nat_gateway_ids), count.index)
   }
 
   tags {
@@ -17,10 +17,10 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_subnet" "private" {
-  vpc_id            = "${var.vpc_id}"
-  cidr_block        = "${var.private_app_subnets[count.index]}"
-  availability_zone = "${var.azs[count.index]}"
-  count             = "${length(var.azs)}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.private_app_subnets[count.index]
+  availability_zone = var.azs[count.index]
+  count             = length(var.azs)
 
   tags {
     Name = "${var.name}-${var.azs[count.index]}"
@@ -32,7 +32,7 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_route_table_association" "private" {
-  count          = "${length(var.azs)}"
-  subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
+  count          = length(var.azs)
+  subnet_id      = element(aws_subnet.private.*.id, count.index)
+  route_table_id = element(aws_route_table.private.*.id, count.index)
 }

--- a/modules/private-app-subnet/output.tf
+++ b/modules/private-app-subnet/output.tf
@@ -1,7 +1,7 @@
 output "subnet_ids" {
-  value = "${join(",", aws_subnet.private.*.id)}"
+  value = join(",", aws_subnet.private.*.id)
 }
 
 output "route_table_ids" {
-  value = "${join(",", aws_route_table.private.*.id)}"
+  value = join(",", aws_route_table.private.*.id)
 }

--- a/modules/private-persistence-subnet/main.tf
+++ b/modules/private-persistence-subnet/main.tf
@@ -1,5 +1,5 @@
 resource "aws_route_table" "persistence" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 
   tags {
     Name = "${var.name}-RT"
@@ -7,10 +7,10 @@ resource "aws_route_table" "persistence" {
 }
 
 resource "aws_subnet" "persistence" {
-  vpc_id            = "${var.vpc_id}"
-  cidr_block        = "${var.private_persistence_subnets[count.index]}"
-  availability_zone = "${var.azs[count.index]}"
-  count             = "${length(var.azs)}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.private_persistence_subnets[count.index]
+  availability_zone = var.azs[count.index]
+  count             = length(var.azs)
 
   tags {
     Name = "${var.name}-${var.azs[count.index]}"
@@ -18,7 +18,7 @@ resource "aws_subnet" "persistence" {
 }
 
 resource "aws_route_table_association" "persistence" {
-  count          = "${length(var.azs)}"
-  subnet_id      = "${element(aws_subnet.persistence.*.id, count.index)}"
-  route_table_id = "${aws_route_table.persistence.id}"
+  count          = length(var.azs)
+  subnet_id      = element(aws_subnet.persistence.*.id, count.index)
+  route_table_id = aws_route_table.persistence.id
 }

--- a/modules/private-persistence-subnet/output.tf
+++ b/modules/private-persistence-subnet/output.tf
@@ -1,3 +1,3 @@
 output "subnet_ids" {
-  value = "${join(",", aws_subnet.persistence.*.id)}"
+  value = join(",", aws_subnet.persistence.*.id)
 }

--- a/modules/public-subnet/main.tf
+++ b/modules/public-subnet/main.tf
@@ -1,5 +1,5 @@
 resource "aws_internet_gateway" "public" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 
   tags {
     Name = "${var.name}-IG"
@@ -7,11 +7,11 @@ resource "aws_internet_gateway" "public" {
 }
 
 resource "aws_route_table" "public" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.public.id}"
+    gateway_id = aws_internet_gateway.public.id
   }
 
   tags {
@@ -20,10 +20,10 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_subnet" "public" {
-  vpc_id            = "${var.vpc_id}"
-  cidr_block        = "${var.public_subnets[count.index]}"
-  availability_zone = "${var.azs[count.index]}"
-  count             = "${length(var.azs)}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.public_subnets[count.index]
+  availability_zone = var.azs[count.index]
+  count             = length(var.azs)
 
   tags {
     Name = "${var.name}-${var.azs[count.index]}"
@@ -37,7 +37,7 @@ resource "aws_subnet" "public" {
 }
 
 resource "aws_route_table_association" "public" {
-  count          = "${length(var.azs)}"
-  subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
-  route_table_id = "${aws_route_table.public.id}"
+  count          = length(var.azs)
+  subnet_id      = element(aws_subnet.public.*.id, count.index)
+  route_table_id = aws_route_table.public.id
 }

--- a/modules/public-subnet/output.tf
+++ b/modules/public-subnet/output.tf
@@ -1,7 +1,7 @@
 output "subnet_ids" {
-  value = "${join(",", aws_subnet.public.*.id)}"
+  value = join(",", aws_subnet.public.*.id)
 }
 
 output "route_table_ids" {
-  value = "${join(",", aws_route_table.public.*.id)}"
+  value = join(",", aws_route_table.public.*.id)
 }

--- a/modules/spare-subnet/main.tf
+++ b/modules/spare-subnet/main.tf
@@ -1,8 +1,8 @@
 resource "aws_subnet" "spare" {
-  vpc_id            = "${var.vpc_id}"
-  cidr_block        = "${var.spare_subnets[count.index]}"
-  availability_zone = "${var.azs[count.index]}"
-  count             = "${length(var.azs)}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.spare_subnets[count.index]
+  availability_zone = var.azs[count.index]
+  count             = length(var.azs)
 
   tags {
     Name = "${var.name}-${var.azs[count.index]}"

--- a/modules/spare-subnet/output.tf
+++ b/modules/spare-subnet/output.tf
@@ -1,3 +1,3 @@
 output "subnet_ids" {
-  value = "${join(",", aws_subnet.spare.*.id)}"
+  value = join(",", aws_subnet.spare.*.id)
 }

--- a/modules/spare-subnet/variables.tf
+++ b/modules/spare-subnet/variables.tf
@@ -6,10 +6,10 @@ variable "vpc_id" {}
 
 variable "spare_subnets" {
   description = "A list of CIDR blocks for spare subnets inside the VPC."
-  type        = "list"
+  type        = list
 }
 
 variable "azs" {
   description = "A list of Availability zones in the region"
-  type        = "list"
+  type        = list
 }

--- a/modules/vpc-peering/main.tf
+++ b/modules/vpc-peering/main.tf
@@ -1,8 +1,8 @@
 resource "aws_vpc_peering_connection" "vpc_peering_connection" {
-  count         = "${length(var.peer_vpc_id) > 0 ? 1 : 0}"
-  peer_owner_id = "${var.peer_owner_id}"
-  peer_vpc_id   = "${var.peer_vpc_id}"
-  vpc_id        = "${var.root_vpc_id}"
+  count         = length(var.peer_vpc_id) > 0 ? 1 : 0
+  peer_owner_id = var.peer_owner_id
+  peer_vpc_id   = var.peer_vpc_id
+  vpc_id        = var.root_vpc_id
   auto_accept   = "true"
 
   tags {
@@ -11,15 +11,15 @@ resource "aws_vpc_peering_connection" "vpc_peering_connection" {
 }
 
 resource "aws_route" "root_to_peer_private_route" {
-  count                     = "${length(var.peer_vpc_id) > 0 ? var.root_route_table_ids_count : 0}"
-  route_table_id            = "${element(split(",", var.root_route_table_ids), count.index)}"
-  destination_cidr_block    = "${var.peer_vpc_cidr}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.vpc_peering_connection.id}"
+  count                     = length(var.peer_vpc_id) > 0 ? var.root_route_table_ids_count : 0
+  route_table_id            = element(split(",", var.root_route_table_ids), count.index)
+  destination_cidr_block    = var.peer_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.vpc_peering_connection.id
 }
 
 resource "aws_route" "peer_to_root_private_route" {
-  count                     = "${length(var.peer_vpc_id) > 0 ? var.root_route_table_ids_count : 0}" # https://github.com/hashicorp/terraform/issues/3888"
-  route_table_id            = "${element(split(",", var.peer_route_table_ids), count.index)}"
-  destination_cidr_block    = "${var.root_vpc_cidr}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.vpc_peering_connection.id}"
+  count                     = length(var.peer_vpc_id) > 0 ? var.root_route_table_ids_count : 0 # https://github.com/hashicorp/terraform/issues/3888"
+  route_table_id            = element(split(",", var.peer_route_table_ids), count.index)
+  destination_cidr_block    = var.root_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.vpc_peering_connection.id
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,8 +1,8 @@
 resource "aws_vpc" "vpc" {
-  cidr_block = "${var.vpc_cidr}"
+  cidr_block = var.vpc_cidr
 
   tags {
-    Name = "${var.name}"
+    Name = var.name
   }
 
   enable_dns_support   = true

--- a/modules/vpc/output.tf
+++ b/modules/vpc/output.tf
@@ -1,7 +1,7 @@
 output "vpc_id" {
-  value = "${aws_vpc.vpc.id}"
+  value = aws_vpc.vpc.id
 }
 
 output "vpc_cidr" {
-  value = "${aws_vpc.vpc.cidr_block}"
+  value = aws_vpc.vpc.cidr_block
 }


### PR DESCRIPTION
Hi folks. Thanks for the repo, I know I am late for the party, just decided to learn few things around and stumbled upon your repo.
Since the last change was made ~5 years ago terraform started to emit warnings when validating. I've fixed them, hope it would help someone.

There were two warnings:
```
  on network.tf line 70, in variable "bastion_host_allow_ssh_cidrs":                                                                                          
  70:   type        = "list"                                                                                                                                  
                                                                                                                                                              
Terraform 0.11 and earlier required type constraints to be given in quotes,                                                                                   
but that form is now deprecated and will be removed in a future version of                                                                                    
Terraform. To silence this warning, remove the quotes around "list" and write                                                                                 
list(string) instead to explicitly indicate that the list elements are                                                                                        
strings.                                                                                                                                                      
                                                                                                                                                              
(and 3 more similar warnings elsewhere)
```

And

```
Warning: Interpolation-only expressions are deprecated                                                                                                        
                                                                                                                                                              
  on network.tf line 86, in module "vpc":                                                                                                                     
  86:   vpc_cidr = "${var.vpc_cidr}"                                                                                                                          
                                                                                                                                                              
Terraform 0.11 and earlier required all non-constant expressions to be                                                                                        
provided via interpolation syntax, but this pattern is now deprecated. To                                                                                     
silence this warning, remove the "${ sequence from the start and the }"                                                                                       
sequence from the end of this expression, leaving just the inner expression.                                                                                  
                                                                                                                                                              
Template interpolation syntax is still used to construct strings from                                                                                         
expressions when the template includes multiple interpolation sequences or a                                                                                  
mixture of literal strings and interpolations. This deprecation applies only                                                                                  
to templates that consist entirely of a single interpolation sequence.
```

Hence two commits.